### PR TITLE
Annotation system for commands

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,26 @@
                     <target>8</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>validate</id>
+                        <phase>validate</phase>
+                        <configuration>
+                            <configLocation>src/main/resources/checkstyle.xml</configLocation>
+                            <encoding>UTF-8</encoding>
+                            <consoleOutput>true</consoleOutput>
+                            <failsOnError>true</failsOnError>
+                        </configuration>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,11 +7,15 @@
     <groupId>de.seine_eloquenz</groupId>
     <artifactId>lbcfs</artifactId>
     <version>1.0-SNAPSHOT</version>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.6.1</version>
                 <configuration>
                     <source>8</source>
                     <target>8</target>
@@ -30,7 +34,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>plugin-annotations</artifactId>
-            <version>1.1.0-SNAPSHOT</version>
+            <version>1.2.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,32 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.spigotmc:plugin-annotations</include>
+                                </includes>
+                            </artifactSet>
+                        <relocations>
+                            <relocation>
+                                <pattern>org.bukkit.plugin.java.annotation</pattern>
+                                <shadedPattern>de.seine_eloquenz.shaded.annotation</shadedPattern>
+                            </relocation>
+                        </relocations>
+                    </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>3.0.0</version>
                 <executions>

--- a/src/main/java/de/seine_eloquenz/lbcfs/Lbcfs.java
+++ b/src/main/java/de/seine_eloquenz/lbcfs/Lbcfs.java
@@ -1,6 +1,10 @@
 package de.seine_eloquenz.lbcfs;
 
+import de.seine_eloquenz.lbcfs.commands.CmdLbcfs;
 import org.bukkit.ChatColor;
+import org.bukkit.plugin.java.annotation.permission.Permission;
+import org.bukkit.plugin.java.annotation.plugin.Plugin;
+import org.bukkit.plugin.java.annotation.plugin.author.Author;
 
 import java.util.Locale;
 import java.util.ResourceBundle;
@@ -8,12 +12,14 @@ import java.util.ResourceBundle;
 /**
  * Lbcfs main plugin class
  */
+@Plugin(name = "LBCFS", version = "1.0")
+@Author("Alexander Linder")
+@Permission(name = "lbcfs.admin", desc = "This player acts as an administrator for LBCFS")
 public final class Lbcfs extends LbcfsPlugin {
 
-
     private static final String BUNDLE_NAME = "locale/Locale";
-    private static final String PRIMARY_COLOR_KEY = "primaryColour";
-    private static final String SECONDARY_COLOR_KEY = "secondaryColour";
+    private static final String PRIMARY_COLOR_KEY = "primaryColor";
+    private static final String SECONDARY_COLOR_KEY = "secondaryColor";
 
     private static Lbcfs instance;
     private Locale locale;

--- a/src/main/java/de/seine_eloquenz/lbcfs/Lbcfs.java
+++ b/src/main/java/de/seine_eloquenz/lbcfs/Lbcfs.java
@@ -33,6 +33,7 @@ public final class Lbcfs extends LbcfsPlugin {
     public void setup() {
         instance = this;
         locale = new Locale(this.getConfig().getString("language"));
+        addCommand(new CmdLbcfs(this));
     }
 
     /**

--- a/src/main/java/de/seine_eloquenz/lbcfs/LbcfsPlugin.java
+++ b/src/main/java/de/seine_eloquenz/lbcfs/LbcfsPlugin.java
@@ -16,8 +16,6 @@ import java.util.ResourceBundle;
  * The LbcfsPlugin class represents a plugin created via the Lbcfs framework. The class implements {@link JavaPlugin}
  * and works the same under the hood.
  *
- * The
- *
  * The {@link LbcfsPlugin#setup()} and {@link LbcfsPlugin#tearDown()} replace the methods {@link JavaPlugin#onEnable()}
  * and {@link JavaPlugin#onDisable()} of normal spigot plugins.
  */
@@ -83,7 +81,7 @@ public abstract class LbcfsPlugin extends JavaPlugin {
      * @param message   message to be sent
      */
     public final void send(final CommandSender recipient, final String message) {
-        ChatIO.send(recipient, message, this.getChatPrefix());
+        ChatIO.send(recipient, this.getChatPrefix(), message);
     }
 
 
@@ -120,7 +118,7 @@ public abstract class LbcfsPlugin extends JavaPlugin {
      * @param message message to send
      */
     public final void broadcast(final String message) {
-        ChatIO.broadcast(message, this.getChatPrefix());
+        ChatIO.broadcast(this.getChatPrefix(), message);
     }
 
     /**
@@ -129,7 +127,7 @@ public abstract class LbcfsPlugin extends JavaPlugin {
      * @param permission permission to send to
      */
     public final void broadcast(final String message, final String permission) {
-        ChatIO.broadcast(message, this.getChatPrefix(), permission);
+        ChatIO.broadcast(this.getChatPrefix(), message, permission);
     }
 
     /**

--- a/src/main/java/de/seine_eloquenz/lbcfs/annotations/command/MaxArgs.java
+++ b/src/main/java/de/seine_eloquenz/lbcfs/annotations/command/MaxArgs.java
@@ -1,0 +1,23 @@
+package de.seine_eloquenz.lbcfs.annotations.command;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Specifies the maximum amount of parameters that can be supplied to a
+ * {@link de.seine_eloquenz.lbcfs.command.LbcfsCommand} or a {@link de.seine_eloquenz.lbcfs.command.SubCommand}
+ */
+@Documented
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MaxArgs {
+
+    /**
+     * The maximum number of arguments that may be supplied
+     * @return the maximum parameter count
+     */
+    int value();
+}

--- a/src/main/java/de/seine_eloquenz/lbcfs/annotations/command/MinArgs.java
+++ b/src/main/java/de/seine_eloquenz/lbcfs/annotations/command/MinArgs.java
@@ -1,0 +1,23 @@
+package de.seine_eloquenz.lbcfs.annotations.command;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Specifies the minimum amount of parameters that can be supplied to a
+ * {@link de.seine_eloquenz.lbcfs.command.LbcfsCommand} or a {@link de.seine_eloquenz.lbcfs.command.SubCommand}
+ */
+@Documented
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MinArgs {
+
+    /**
+     * The maximum number of arguments that may be supplied
+     * @return the maximum parameter count
+     */
+    int value();
+}

--- a/src/main/java/de/seine_eloquenz/lbcfs/annotations/command/PlayerOnly.java
+++ b/src/main/java/de/seine_eloquenz/lbcfs/annotations/command/PlayerOnly.java
@@ -1,0 +1,21 @@
+package de.seine_eloquenz.lbcfs.annotations.command;
+
+import de.seine_eloquenz.lbcfs.command.LbcfsCommand;
+import de.seine_eloquenz.lbcfs.command.SubCommand;
+import org.bukkit.entity.Player;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation marks the {@link LbcfsCommand} or {@link SubCommand} it is used on to only be issued by an online
+ * {@link Player}
+ */
+@Documented
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PlayerOnly {
+}

--- a/src/main/java/de/seine_eloquenz/lbcfs/annotations/command/SubCommand.java
+++ b/src/main/java/de/seine_eloquenz/lbcfs/annotations/command/SubCommand.java
@@ -1,0 +1,24 @@
+package de.seine_eloquenz.lbcfs.annotations.command;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Specifies a {@link de.seine_eloquenz.lbcfs.command.SubCommand} that belongs to a {@link de.seine_eloquenz.lbcfs.command.LbcfsCommand}
+ */
+@Documented
+@Target(ElementType.TYPE)
+@Repeatable(SubCommands.class)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SubCommand {
+
+    /**
+     * The class of the {@link SubCommand}
+     * @return the subCommand class
+     */
+    Class value();
+}

--- a/src/main/java/de/seine_eloquenz/lbcfs/annotations/command/SubCommandName.java
+++ b/src/main/java/de/seine_eloquenz/lbcfs/annotations/command/SubCommandName.java
@@ -1,0 +1,22 @@
+package de.seine_eloquenz.lbcfs.annotations.command;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Specifies the name of a {@link de.seine_eloquenz.lbcfs.command.SubCommand}
+ */
+@Documented
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SubCommandName {
+
+    /**
+     * The name of the subCommand
+     * @return name
+     */
+    String value();
+}

--- a/src/main/java/de/seine_eloquenz/lbcfs/annotations/command/SubCommands.java
+++ b/src/main/java/de/seine_eloquenz/lbcfs/annotations/command/SubCommands.java
@@ -1,0 +1,22 @@
+package de.seine_eloquenz.lbcfs.annotations.command;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Container annotation for {@link SubCommand}s
+ */
+@Documented
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SubCommands {
+
+    /**
+     * The {@link SubCommand}s stored in the {@link SubCommands}
+     * @return the subcommand array
+     */
+    SubCommand[] value();
+}

--- a/src/main/java/de/seine_eloquenz/lbcfs/command/LbcfsCommand.java
+++ b/src/main/java/de/seine_eloquenz/lbcfs/command/LbcfsCommand.java
@@ -2,6 +2,7 @@ package de.seine_eloquenz.lbcfs.command;
 
 import de.seine_eloquenz.lbcfs.Lbcfs;
 import de.seine_eloquenz.lbcfs.LbcfsPlugin;
+import de.seine_eloquenz.lbcfs.annotations.command.PlayerOnly;
 import de.seine_eloquenz.lbcfs.io.messaging.ChatIO;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
@@ -21,18 +22,6 @@ public abstract class LbcfsCommand implements CommandExecutor {
     private final Map<String, SubCommand> subCommands;
     private final int minParams;
     private final int maxParams;
-    private final boolean playerOnly;
-
-    /**
-     * Creates a new LbcfsCommand without parameters for the given plugin which is issuable by any sender
-     * Name may not be "?" as this is reserved
-     *
-     * @param name name of the command
-     * @param plugin the plugin this command belongs to
-     */
-    public LbcfsCommand(final String name, final LbcfsPlugin plugin) {
-        this(name, plugin, 0, 0, false);
-    }
 
     /**
      * Creates a new LbcfsCommand without parameters for the given plugin
@@ -40,10 +29,9 @@ public abstract class LbcfsCommand implements CommandExecutor {
      *
      * @param name name of the command
      * @param plugin the plugin this command belongs to
-     * @param playerOnly whether this command can only be issued by a player or not
      */
-    public LbcfsCommand(final String name, final LbcfsPlugin plugin, final boolean playerOnly) {
-        this(name, plugin, 0, 0, playerOnly);
+    public LbcfsCommand(final String name, final LbcfsPlugin plugin) {
+        this(name, plugin, 0, 0);
     }
 
     /**
@@ -54,9 +42,8 @@ public abstract class LbcfsCommand implements CommandExecutor {
      * @param plugin the plugin this command belongs to
      * @param minParams minimal number of command parameters
      * @param maxParams maximal number of command parameters
-     * @param playerOnly whether this command can only be issued by a player or not
      */
-    public LbcfsCommand(final String name, final LbcfsPlugin plugin, final int minParams, final int maxParams, final boolean playerOnly) {
+    public LbcfsCommand(final String name, final LbcfsPlugin plugin, final int minParams, final int maxParams) {
         if ("?".equals(name)) {
             throw new IllegalArgumentException("Invalid name '" + name + "'!");
         }
@@ -65,7 +52,6 @@ public abstract class LbcfsCommand implements CommandExecutor {
         subCommands = new HashMap<>();
         this.minParams = minParams;
         this.maxParams = maxParams;
-        this.playerOnly = playerOnly;
     }
 
     private String[] cutFirstParam(final String[] params) {
@@ -119,7 +105,7 @@ public abstract class LbcfsCommand implements CommandExecutor {
      * @return true if execution was completed without errors, false otherwise
      */
     private boolean runLogic(final CommandSender sender, final String[] params) {
-        if (playerOnly && !(sender instanceof Player)) {
+        if (isPlayerOnly() && !(sender instanceof Player)) {
             sender.sendMessage(Lbcfs.getLbcfsMessage("playersOnly"));
             return true;
         }
@@ -168,5 +154,9 @@ public abstract class LbcfsCommand implements CommandExecutor {
             ChatIO.sendWithoutPrefix(sender, Lbcfs.getPrimaryColor() + name);
         }
         return true;
+    }
+
+    private boolean isPlayerOnly() {
+        return this.getClass().isAnnotationPresent(PlayerOnly.class);
     }
 }

--- a/src/main/java/de/seine_eloquenz/lbcfs/command/SubCommand.java
+++ b/src/main/java/de/seine_eloquenz/lbcfs/command/SubCommand.java
@@ -1,6 +1,7 @@
 package de.seine_eloquenz.lbcfs.command;
 
 import de.seine_eloquenz.lbcfs.LbcfsPlugin;
+import de.seine_eloquenz.lbcfs.annotations.command.SubCommandName;
 import org.bukkit.command.CommandSender;
 
 /**
@@ -9,29 +10,20 @@ import org.bukkit.command.CommandSender;
 public abstract class SubCommand extends LbcfsCommand {
 
     /**
-     * Creates a new SubCommand with no parameters which can be issued by every {@link CommandSender}
-     * NOTE: Name "?" is reserved for listing of subcommands
-     *
-     * @param name name of the subcommand
-     * @param plugin plugin this command belongs to
-     */
-    public SubCommand(final String name, final LbcfsPlugin plugin) {
-        this(name, plugin, 0, 0);
-    }
-
-    /**
      * Creates a new SubCommand with the given minimal and maximal parameters
      * NOTE: Name "?" is reserved for listing of subcommands
      *
-     * @param name name of the subcommand
      * @param plugin plugin this command belongs to
-     * @param minParams minimum parameter count
-     * @param maxParams maximum parameter count
      */
-    public SubCommand(final String name, final LbcfsPlugin plugin, final int minParams, final int maxParams) {
-        super(name, plugin, minParams, maxParams);
+    public SubCommand(final LbcfsPlugin plugin) {
+        super(plugin);
     }
 
     @Override
     public abstract boolean run(CommandSender sender, String[] args);
+
+    @Override
+    public String getName() {
+        return this.getClass().getAnnotation(SubCommandName.class).value();
+    }
 }

--- a/src/main/java/de/seine_eloquenz/lbcfs/command/SubCommand.java
+++ b/src/main/java/de/seine_eloquenz/lbcfs/command/SubCommand.java
@@ -16,20 +16,7 @@ public abstract class SubCommand extends LbcfsCommand {
      * @param plugin plugin this command belongs to
      */
     public SubCommand(final String name, final LbcfsPlugin plugin) {
-        this(name, plugin, 0, 0, false);
-    }
-
-    /**
-     * Creates a new SubCommand with the given minimal and maximal parameters by every {@link CommandSender}
-     * NOTE: Name "?" is reserved for listing of subcommands
-     *
-     * @param name name of the subcommand
-     * @param plugin plugin this command belongs to
-     * @param minParams minimum parameter count
-     * @param maxParams maximum parameter count
-     */
-    public SubCommand(final String name, final LbcfsPlugin plugin, final int minParams, final int maxParams) {
-        this(name, plugin, minParams, maxParams, false);
+        this(name, plugin, 0, 0);
     }
 
     /**
@@ -40,10 +27,9 @@ public abstract class SubCommand extends LbcfsCommand {
      * @param plugin plugin this command belongs to
      * @param minParams minimum parameter count
      * @param maxParams maximum parameter count
-     * @param playerOnly whether only players can execute the command or not
      */
-    public SubCommand(final String name, final LbcfsPlugin plugin, final int minParams, final int maxParams, final boolean playerOnly) {
-        super(name, plugin, minParams, maxParams, playerOnly);
+    public SubCommand(final String name, final LbcfsPlugin plugin, final int minParams, final int maxParams) {
+        super(name, plugin, minParams, maxParams);
     }
 
     @Override

--- a/src/main/java/de/seine_eloquenz/lbcfs/commands/CmdLbcfs.java
+++ b/src/main/java/de/seine_eloquenz/lbcfs/commands/CmdLbcfs.java
@@ -1,0 +1,28 @@
+package de.seine_eloquenz.lbcfs.commands;
+
+import de.seine_eloquenz.lbcfs.LbcfsPlugin;
+import de.seine_eloquenz.lbcfs.annotations.command.SubCommand;
+import de.seine_eloquenz.lbcfs.command.LbcfsCommand;
+import org.bukkit.command.CommandSender;
+import org.bukkit.plugin.java.annotation.command.Command;
+
+/**
+ * Prints the version of Lbcfs in chat
+ */
+@Command(name = "lbcfs")
+@SubCommand(SubCmdVersion.class)
+public class CmdLbcfs extends LbcfsCommand {
+
+    /**
+     * Constructs a new {@link CmdLbcfs} object
+     * @param plugin plugin the command belongs to
+     */
+    public CmdLbcfs(final LbcfsPlugin plugin) {
+        super(plugin);
+    }
+
+    @Override
+    public boolean run(final CommandSender sender, final String[] args) {
+        return false;
+    }
+}

--- a/src/main/java/de/seine_eloquenz/lbcfs/commands/SubCmdVersion.java
+++ b/src/main/java/de/seine_eloquenz/lbcfs/commands/SubCmdVersion.java
@@ -1,0 +1,29 @@
+package de.seine_eloquenz.lbcfs.commands;
+
+import de.seine_eloquenz.lbcfs.LbcfsPlugin;
+import de.seine_eloquenz.lbcfs.annotations.command.SubCommandName;
+import de.seine_eloquenz.lbcfs.command.SubCommand;
+import org.bukkit.command.CommandSender;
+
+/**
+ * This subcommand prints the version of lbcfs into chat
+ */
+@SubCommandName("version")
+public class SubCmdVersion extends SubCommand {
+
+    /**
+     * Creates a new SubCommand with the given minimal and maximal parameters
+     * NOTE: Name "?" is reserved for listing of subcommands
+     *
+     * @param plugin plugin this command belongs to
+     */
+    public SubCmdVersion(final LbcfsPlugin plugin) {
+        super(plugin);
+    }
+
+    @Override
+    public boolean run(final CommandSender sender, final String[] args) {
+        this.getPlugin().send(sender, this.getPlugin().getMessage("version") + ": " + this.getPlugin().getDescription().getVersion());
+        return true;
+    }
+}

--- a/src/main/java/de/seine_eloquenz/lbcfs/io/messaging/ChatIO.java
+++ b/src/main/java/de/seine_eloquenz/lbcfs/io/messaging/ChatIO.java
@@ -18,8 +18,8 @@ public final class ChatIO {
      * Sends a message to a CommandSender
      *
      * @param recipient recipient to send the message to
-     * @param message   message to be sent
      * @param prefix    prefix to be put in front
+     * @param message   message to be sent
      */
     public static void send(final CommandSender recipient, final String prefix, final String message) {
         recipient.sendMessage(compileMessage(message, prefix));
@@ -48,21 +48,21 @@ public final class ChatIO {
     /**
      * Broadcasts a message to all online players
      *
-     * @param message message to be sent
      * @param prefix  prefix to be put in front
+     * @param message message to be sent
      */
-    public static void broadcast(final String message, final String prefix) {
+    public static void broadcast(final String prefix, final String message) {
         Bukkit.broadcastMessage(compileMessage(message, prefix));
     }
 
     /**
      * Broadcasts a message to all online players with the given permission
      *
-     * @param message message to be sent
      * @param prefix  prefix to be put in front
+     * @param message message to be sent
      * @param permission permission to send to
      */
-    public static void broadcast(final String message, final String prefix, final String permission) {
+    public static void broadcast(final String prefix, final String message, final String permission) {
         Bukkit.broadcast(compileMessage(message, prefix), permission);
     }
 

--- a/src/main/resources/locale/Locale.properties
+++ b/src/main/resources/locale/Locale.properties
@@ -4,3 +4,4 @@ commandNoParams=This command must be run without parameters!
 commandAtLeastParams=This command must be run with at least %i parameters!
 commandAtMostParams=This command must be run with at most %i parameters!
 commandParams=This command must be run with at least %i and at most %i parameters!
+version=Version

--- a/src/main/resources/locale/Locale_de.properties
+++ b/src/main/resources/locale/Locale_de.properties
@@ -4,3 +4,4 @@ commandNoParams=Dieses Kommando muss ohne Parameter aufgerufen werden!
 commandAtLeastParams=Dieses Kommando muss mit mindestens %i Parametern aufgerufen werden!
 commandAtMostParams=Dieses Kommando muss mit maximal %i Parametern aufgerufen werden!
 commandParams=Dieses Kommando muss mit mindestens %i und maximal %i Parametern aufgerufen werden!
+version=Version


### PR DESCRIPTION
We use annotations for commands to determine various information like name, subcommands, min/max parameter counts without the need for hugely long constructor calls